### PR TITLE
Pass files through build

### DIFF
--- a/jenkinsc/jenkins.py
+++ b/jenkinsc/jenkins.py
@@ -65,8 +65,8 @@ class JenkinsJob:
     def __getitem__(self, item):
         return self.get_build(item)
 
-    def build(self, build_params=None, block=False):
-        response = self.trigger_build(build_params)
+    def build(self, build_params=None, files=None, block=False):
+        response = self.trigger_build(build_params, files=files)
         qi = QueueItem(response.headers['Location'], self.auth)
         if block:
             qi.get_build().wait_till_completion()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.md') as file:
 setup(
     name='jenkinsc',
     packages=find_packages(include=('jenkinsc', )),
-    version='0.0.32',
+    version='0.0.34',
     description='bulletproof jenkins client',
     author='Alex Buchkovsky',
     long_description=long_description,


### PR DESCRIPTION
Add `files` parameter to the build method as it is supposed to be the main entry point.