### PR TITLE
Allow to receive file param content

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.md') as file:
 setup(
     name='jenkinsc',
     packages=find_packages(include=('jenkinsc', )),
-    version='0.0.34',
+    version='0.0.35',
     description='bulletproof jenkins client',
     author='Alex Buchkovsky',
     long_description=long_description,


### PR DESCRIPTION
It is not easy to find path of the file uploaded through the file
parameter. An easy way is to use default file preview URL which can be accessed by clicking `view` link near the file parameter.