### PR TITLE
Add missing arguments

### DIFF
--- a/jenkinsc/jenkins.py
+++ b/jenkinsc/jenkins.py
@@ -237,8 +237,9 @@ class Build:
 
     @lost_connection_wrapper
     def update_build_name(self, new_build_name):
+        parameters = json.dumps({'displayName': new_build_name, 'description': ''})
         response = requests.post('{}/configSubmit'.format(self.url),
-                                 data={'json': json.dumps({'displayName': new_build_name, 'description': ''})},
+                                 data={'Submit': 'Save', 'core:apply': '', 'json': parameters},
                                  auth=self.auth)
         if response.status_code not in [200, 201]:
             response.raise_for_status()


### PR DESCRIPTION
Submit: Save and core:apply seems to be required as build name is going
to be overwritten to default otherwise.